### PR TITLE
rem-calc() function created

### DIFF
--- a/src/constants/functions.ts
+++ b/src/constants/functions.ts
@@ -1,0 +1,7 @@
+export const remCalc = (px: number): number => {
+  const baseFontSizeInPx = 16;
+
+  const remValue = px / baseFontSizeInPx;
+
+  return remValue;
+};


### PR DESCRIPTION
rem-calc() is a function that allows you to create an equivalent rem according to a px number.